### PR TITLE
fix issue with annotations

### DIFF
--- a/task.sh
+++ b/task.sh
@@ -14,7 +14,7 @@ while getopts ":r:f:" opt; do
   case $opt in
     r) reload_rate="$OPTARG"
     ;;
-    p) filter="$OPTARG"
+    f) filter="$OPTARG"
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;

--- a/task.sh
+++ b/task.sh
@@ -31,7 +31,7 @@ echo_task () {
 		index=-1
 	fi
 	current_desc=`echo "${descriptions}" | sed -n $((index))p`
-	current_due=`task $filter rc.verbose: rc.report.minimal.columns:due.relative rc.report.minimal.sort=id rc.report.minimal.labels:1 minimal | sed -n $((index))p`
+	current_due=`task $filter rc.verbose: rc.report.minimal.columns:id,due.relative rc.report.minimal.sort=id rc.report.minimal.labels:1,1 minimal | sed  -e "s/^[[:digit:]]\+$//" -e "s/^[[:digit:]]\+\s\+//" | sed -n $((index))p`
 	echo "$index" > /tmp/tw_polybar_id
 	if [ -z "$current_due" ]
 	then

--- a/task.sh
+++ b/task.sh
@@ -23,7 +23,7 @@ done
 
 # echo the task with the specified id
 echo_task () {
-	descriptions=`task $filter rc.verbose: rc.report.minimal.columns:description.count rc.report.minimal.labels:1 minimal`
+	descriptions=`task $filter rc.verbose: rc.report.minimal.columns:description.count rc.report.minimal.sort=id rc.report.minimal.labels:1 minimal`
 	count=`echo "${descriptions}" | wc -l`
 	if [ $count -gt 0 ]; then
 		index=$(((index-1) % count + 1))
@@ -31,7 +31,7 @@ echo_task () {
 		index=-1
 	fi
 	current_desc=`echo "${descriptions}" | sed -n $((index))p`
-	current_due=`task $filter rc.verbose: rc.report.next.columns:due.relative rc.report.next.labels:1 next | sed -n $((index))p`
+	current_due=`task $filter rc.verbose: rc.report.minimal.columns:due.relative rc.report.minimal.sort=id rc.report.minimal.labels:1 minimal | sed -n $((index))p`
 	echo "$index" > /tmp/tw_polybar_id
 	if [ -z "$current_due" ]
 	then

--- a/task.sh
+++ b/task.sh
@@ -23,9 +23,9 @@ done
 
 # echo the task with the specified id
 echo_task () {
-	descriptions=`task $filter rc.verbose: rc.report.next.columns:description rc.report.next.labels:1 next`
+	descriptions=`task $filter rc.verbose: rc.report.minimal.columns:description.count rc.report.minimal.labels:1 minimal`
 	count=`echo "${descriptions}" | wc -l`
-	if [ $count -gt 0 ]; then 
+	if [ $count -gt 0 ]; then
 		index=$(((index-1) % count + 1))
 	else
 		index=-1
@@ -55,7 +55,7 @@ cancel_marking() {
 	marking=0
 	echo Canceled!
 	sleep 1 &
-	wait 
+	wait
 	echo_task
 }
 click1() {
@@ -63,7 +63,7 @@ click1() {
 		# increment $index and display next task
 		((index++))
 		echo_task
- 
+
 	else
 		cancel_marking
 	fi

--- a/task.sh
+++ b/task.sh
@@ -32,7 +32,7 @@ echo_task () {
 	fi
 	current_desc=`echo "${descriptions}" | sed -n $((index))p`
 	current_due=`task $filter rc.verbose: rc.report.next.columns:due.relative rc.report.next.labels:1 next | sed -n $((index))p`
-	echo "$1" > /tmp/tw_polybar_id
+	echo "$index" > /tmp/tw_polybar_id
 	if [ -z "$current_due" ]
 	then
 		echo " $current_desc"


### PR DESCRIPTION
The description of the tasks with annotations returns several lines if we use the report next.
Using minimal fix the issue, description will contain the main description followed by a count [x] of annotations.

Mark as done was not working as $1 was using instead of $index.

getops was expect f for filter but we had "p" in the case statement.